### PR TITLE
Weave adapted to work with Python 3.4

### DIFF
--- a/examples/object.py
+++ b/examples/object.py
@@ -43,7 +43,7 @@ print('initial, inc(2), set(5)/get:', weave.inline(code,['obj']))
 #----------------------------------------------------------------------------
 # indexing of values.
 #----------------------------------------------------------------------------
-from UserList import UserList
+from collections import UserList
 obj = UserList([1,[1,2],"hello"])
 code = """
        int i;

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ import subprocess
 import os
 
 
-if not sys.version_info[:2] in [(2, 6), (2, 7)]:
+if not sys.version_info[:2] in [(2, 6), (2, 7), (3, 4)]:
     raise RuntimeError("Python version 2.6 or 2.7 required.")
 
 

--- a/weave/__init__.py
+++ b/weave/__init__.py
@@ -21,7 +21,7 @@ from __future__ import absolute_import, print_function
 import sys
 
 
-if not sys.version_info[:2] in [(2, 6), (2, 7)]:
+if not sys.version_info[:2] in [(2, 6), (2, 7), (3, 4)]:
     raise RuntimeError("Weave only supports Python 2.6 and 2.7")
 
 

--- a/weave/base_info.py
+++ b/weave/base_info.py
@@ -10,7 +10,7 @@
 """
 from __future__ import absolute_import, print_function
 
-import UserList
+import collections
 
 
 class base_info(object):
@@ -128,7 +128,7 @@ class custom_info(base_info):
         return self._extra_link_args.append(link_arg)
 
 
-class info_list(UserList.UserList):
+class info_list(collections.UserList):
     def get_unique_values(self,attribute):
         all_values = []
         for info in self:

--- a/weave/base_spec.py
+++ b/weave/base_spec.py
@@ -84,11 +84,11 @@ class base_converter(object):
     def variable_as_string(self):
         return '"' + self.name + '"'
 
-import UserList
+import collections
 from . import base_info
 
 
-class arg_spec_list(UserList.UserList):
+class arg_spec_list(collections.UserList):
     def build_information(self):
         all_info = base_info.info_list()
         for i in self:

--- a/weave/build_tools.py
+++ b/weave/build_tools.py
@@ -22,8 +22,8 @@ import sys
 import os
 import time
 import tempfile
-import commands
 import subprocess
+commands = subprocess
 import warnings
 
 from . import platform_info

--- a/weave/c_spec.py
+++ b/weave/c_spec.py
@@ -4,6 +4,9 @@ import types
 from .base_spec import base_converter
 from . import base_info
 
+import io 
+long = int
+
 #----------------------------------------------------------------------------
 # C++ code template for converting code from python objects to C++ objects
 #
@@ -218,7 +221,7 @@ class string_converter(common_base_converter):
         self.c_type = 'std::string'
         self.return_type = 'std::string'
         self.to_c_return = "std::string(PyString_AsString(py_obj))"
-        self.matching_types = [types.StringType]
+        self.matching_types = [bytes]
         self.headers.append('<string>')
 
     def c_to_py_code(self):
@@ -247,7 +250,7 @@ class unicode_converter(common_base_converter):
         self.c_type = 'Py_UNICODE*'
         self.return_type = self.c_type
         self.to_c_return = "PyUnicode_AS_UNICODE(py_obj)"
-        self.matching_types = [types.UnicodeType]
+        self.matching_types = [str]
         # self.headers.append('<string>')
 
     def declaration_code(self,templatize=0,inline=0):
@@ -273,7 +276,7 @@ class file_converter(common_base_converter):
         self.return_type = self.c_type
         self.to_c_return = "PyFile_AsFile(py_obj)"
         self.headers = ['<stdio.h>']
-        self.matching_types = [types.FileType]
+        self.matching_types = [io.IOBase]
 
     def c_to_py_code(self):
         # !! Need to dedent returned code.
@@ -351,7 +354,7 @@ class int_converter(scalar_converter):
         self.c_type = 'int'
         self.return_type = 'int'
         self.to_c_return = "(int) PyInt_AsLong(py_obj)"
-        self.matching_types = [types.IntType]
+        self.matching_types = [int]
 
 
 class long_converter(scalar_converter):
@@ -363,7 +366,7 @@ class long_converter(scalar_converter):
         self.c_type = 'longlong'
         self.return_type = 'longlong'
         self.to_c_return = "(longlong) PyLong_AsLongLong(py_obj)"
-        self.matching_types = [types.LongType]
+        self.matching_types = [int]
 
 
 class float_converter(scalar_converter):
@@ -375,7 +378,7 @@ class float_converter(scalar_converter):
         self.c_type = 'double'
         self.return_type = 'double'
         self.to_c_return = "PyFloat_AsDouble(py_obj)"
-        self.matching_types = [types.FloatType]
+        self.matching_types = [float]
 
 
 class complex_converter(scalar_converter):
@@ -387,7 +390,7 @@ class complex_converter(scalar_converter):
         self.return_type = 'std::complex<double>'
         self.to_c_return = "std::complex<double>(PyComplex_RealAsDouble(py_obj),"\
                                                 "PyComplex_ImagAsDouble(py_obj))"
-        self.matching_types = [types.ComplexType]
+        self.matching_types = [complex]
 
 #----------------------------------------------------------------------------
 #
@@ -417,7 +420,7 @@ class list_converter(scxx_converter):
         self.c_type = 'py::list'
         self.return_type = 'py::list'
         self.to_c_return = 'py::list(py_obj)'
-        self.matching_types = [types.ListType]
+        self.matching_types = [list]
         # ref counting handled by py::list
         self.use_ref_count = 0
 
@@ -430,7 +433,7 @@ class tuple_converter(scxx_converter):
         self.c_type = 'py::tuple'
         self.return_type = 'py::tuple'
         self.to_c_return = 'py::tuple(py_obj)'
-        self.matching_types = [types.TupleType]
+        self.matching_types = [tuple]
         # ref counting handled by py::tuple
         self.use_ref_count = 0
 
@@ -443,7 +446,7 @@ class dict_converter(scxx_converter):
         self.c_type = 'py::dict'
         self.return_type = 'py::dict'
         self.to_c_return = 'py::dict(py_obj)'
-        self.matching_types = [types.DictType]
+        self.matching_types = [dict]
         # ref counting handled by py::dict
         self.use_ref_count = 0
 
@@ -460,7 +463,7 @@ class instance_converter(scxx_converter):
         self.c_type = 'py::object'
         self.return_type = 'py::object'
         self.to_c_return = 'py::object(py_obj)'
-        self.matching_types = [types.InstanceType]
+        self.matching_types = [object]
         # ref counting handled by py::object
         self.use_ref_count = 0
 

--- a/weave/size_check.py
+++ b/weave/size_check.py
@@ -7,6 +7,8 @@ from numpy import ones, ndarray, array, asarray, concatenate, zeros, shape, \
 
 import sys
 
+long = int
+
 numericTypes = (int, long, float, complex)
 
 

--- a/weave/tests/test_scxx_object.py
+++ b/weave/tests/test_scxx_object.py
@@ -3,7 +3,7 @@
 from __future__ import absolute_import, print_function
 
 import sys
-from UserList import UserList
+from collections import UserList
 
 from numpy.testing import (TestCase, dec, assert_equal, assert_, assert_raises,
                            run_module_suite)


### PR DESCRIPTION
This PR is the start of work to adapt Weave to work with Python 2.7 and Python 3.4 (as a minimum).  The work done in this PR to date is very preliminary and only aims to evaluate the minimum set of modifications required to make `runtest.py` execute.  It currently runs (in Python 3.4 only) but every test fails.