### PR TITLE
Test subcommand of setup.py requires setuptools as well.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -194,7 +194,7 @@ def setup_package():
         FULLVERSION, GIT_REVISION = get_version_info()
         metadata['version'] = FULLVERSION
     else:
-        if len(sys.argv) >= 2 and sys.argv[1] == 'bdist_wheel':
+        if len(sys.argv) >= 2 and sys.argv[1] in ['bdist_wheel', 'test']:
             # bdist_wheel needs setuptools
             import setuptools
 


### PR DESCRIPTION
For openSUSE package I would love to have ``python setup.py test`` command working, but it isn't because for ``test`` subcommand doesn't use setuptools. This pull requests fixes that.